### PR TITLE
Use `Threat:GetModule` for better module handling

### DIFF
--- a/Modules/List.lua
+++ b/Modules/List.lua
@@ -12,8 +12,6 @@ List.nBarSlots = 0
 --[[ Initial functions ]]--
 
 function List:OnInitialize()
-	Threat:GetModule("Main").ModuleList = self
-
 	self.oXml = XmlDoc.CreateFromFile("Forms/List.xml")
 
 	if self.oXml == nil then

--- a/Modules/Main.lua
+++ b/Modules/Main.lua
@@ -10,10 +10,6 @@ Main.tThreatList = {}
 Main.bCanInstantUpdate = true
 Main.bUpdateAwaiting = false
 
-Main.ModuleList = nil
-Main.ModuleNotify = nil
-Main.ModuleMini = nil
-
 Main.bInPreview = false
 
 function Main:OnInitialize()
@@ -100,10 +96,6 @@ function Main:UpdateUI()
 	-- Checks
 	if self.bInPreview then return end
 
-	if self.ModuleList == nil or self.ModuleNotify == nil or self.ModuleMini == nil then
-		return
-	end
-
 	if (#self.tThreatList < 1) or (not Threat.tOptions.profile.bShowSolo and #self.tThreatList < 2) then
 		self.ClearUI()
 		return
@@ -157,12 +149,12 @@ function Main:UpdateUI()
 
 	-- List:
 	if self:GetShowModule(Threat.tOptions.profile.tList.nShow, bInGroup, bInRaid) then
-		self.ModuleList:Update(self.tThreatList, oPlayer:GetId(), nTopThreatFirst)
+		Threat:GetModule("List"):Update(self.tThreatList, oPlayer:GetId(), nTopThreatFirst)
 	end
 
 	-- Notification:
 	if self:GetShowModule(Threat.tOptions.profile.tNotify.nShow, bInGroup, bInRaid) then
-		self.ModuleNotify:Update(bIsPlayerTank, nPlayerValue, nTopThreatFirst)
+		Threat:GetModule("Notify"):Update(bIsPlayerTank, nPlayerValue, nTopThreatFirst)
 	end
 
 	-- Mini:
@@ -171,13 +163,13 @@ end
 function Main:ClearUI()
 	if self.bInPreview then return end
 
-	if self.ModuleList == nil or self.ModuleNotify == nil or self.ModuleMini == nil then
+	if Threat:GetModule("List") == nil or Threat:GetModule("Notify") == nil or Threat:GetModule("Mini") == nil then
 		return
 	end
 
 	-- Calling UI module clears
-	self.ModuleList:Clear()
-	self.ModuleNotify:Clear()
+	Threat:GetModule("List"):Clear()
+	Threat:GetModule("Notify"):Clear()
 end
 
 function Main:GetShowModule(nSetting, bInGroup, bInRaid)

--- a/Modules/Mini.lua
+++ b/Modules/Mini.lua
@@ -9,7 +9,6 @@ Mini.bActive = false
 --[[ Initial functions ]]--
 
 function Mini:OnInitialize()
-	Threat:GetModule("Main").ModuleMini = self
 end
 
 function Mini:OnEnable()

--- a/Modules/Notify.lua
+++ b/Modules/Notify.lua
@@ -9,8 +9,6 @@ Notify.bActive = false
 --[[ Initial functions ]]--
 
 function Notify:OnInitialize()
-	Threat:GetModule("Main").ModuleNotify = self
-
 	self.oXml = XmlDoc.CreateFromFile("Forms/Notify.xml")
 
 	if self.oXml == nil then


### PR DESCRIPTION
Storing the modules inside the main module isn't the right way to go imho. Simply call `Threat:GetModule(name)` for the ones you need (when you need them).

If you use them multiple times, you can always store them in locals inside the functions that need them. Or if you _really_ want them in the `Main` module, just set them in `Main:OnInitialize()`like this:

```lua
function Main:OnInitialize()
    self.ModuleList = Threat:GetModule("List")
end
```

The modules are already declared before `:OnInitialize()` is called on any module IIRC.

I also removed a superflous `if` statement that was being run twice in `Main:UpdateUI()` and `Main:ClearUI()`.